### PR TITLE
establish sops-age

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .DS_Store
+
+# Ignore plaintext secret files
+*.tfvars
+!*.tfvars.enc

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,5 @@
+creation_rules:
+  - path_regex: \.tfvars$
+    age:
+      # public key: age15sz46c0sm2ql5vcjg9dqmv70st9cg3dy72kgv20l2aa8l2uv0dgqkt6ymv
+      - "age15sz46c0sm2ql5vcjg9dqmv70st9cg3dy72kgv20l2aa8l2uv0dgqkt6ymv"

--- a/docs/runbooks/local_dev_setup.md
+++ b/docs/runbooks/local_dev_setup.md
@@ -1,0 +1,52 @@
+# Runbook: Local Development Setup
+
+This runbook provides step-by-step instructions for setting up a local development environment to work with this repository's ephemeral and secure patterns.
+
+## 1. Tool Installation
+
+You will need the following tools installed on your local machine:
+
+- **[sops](https://github.com/getsops/sops/releases):** For encrypting and decrypting secret files.
+- **[age](https://github.com/FiloSottile/age/releases):** The backend encryption tool used by `sops` in this project.
+- **Terraform:** For infrastructure as code.
+- **aws-vault:** (Recommended for AWS) For managing temporary, short-lived AWS credentials locally, mimicking the OIDC flow in CI.
+
+## 2. `sops+age` Key Setup
+
+This project uses `sops` with `age` to encrypt secrets stored in the repository. You must have a local `age` keypair to decrypt them.
+
+### Step 1: Generate an `age` Keypair
+
+If you don't already have a key, generate one. This command creates a `keys.txt` file in the standard `sops` directory.
+
+```bash
+# For macOS / Linux
+mkdir -p ~/.config/sops/age
+age-keygen -o ~/.config/sops/age/keys.txt
+```
+
+Your public key will be printed to the console. The private key is stored securely in the `keys.txt` file.
+
+**IMPORTANT:** Back up your private key (the `keys.txt` file) to a secure location, like a password manager. If you lose it, you will not be able to decrypt any files encrypted with its corresponding public key.
+
+### Step 2: Add Your Public Key to the Project
+
+To encrypt new secrets or re-encrypt existing ones, your `age` public key must be listed in the `.sops.yaml` file at the root of this repository. If you are the first person setting up the project, add your key. If you are joining, ensure your key is added by a maintainer.
+
+### Step 3: Test Decryption
+
+Verify that you can decrypt an existing secret file.
+
+```bash
+# This command decrypts the file and prints its contents to standard output
+sops --decrypt examples/secrets/example.tfvars.enc
+```
+
+### Step 4: Encrypting a File
+
+Thanks to the `.sops.yaml` configuration, encrypting a file is simple. `sops` will automatically use the public keys listed in the config.
+
+```bash
+# This command encrypts a new or modified tfvars file
+sops --encrypt -i examples/secrets/example.tfvars
+```

--- a/examples/secrets/example.tfvars.enc
+++ b/examples/secrets/example.tfvars.enc
@@ -1,0 +1,14 @@
+{
+	"data": "ENC[AES256_GCM,data:rjdepTrVMymKpKg3g+byeVMDyADllTbVUNmJSljAitiGjAiPOzAuwAnlEu08NDFXK278HG7uuAm5YYSx+2s16zPVMVFBCZC4zDk22limj91aLX0A//2oGNJIj9t31HOHzAdZFStr30n2GJ/3RTlohUSafhJhKNa8YHmSc7t7i8uxNOj+KRR0ZQ4A4UMa,iv:cn7wHHpLpYu/oSYRSXOHoDEm6TZijZIl+qbcuCNA03o=,tag:N47ouVgSaZ7aDBG1XjmwRg==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"recipient": "age15sz46c0sm2ql5vcjg9dqmv70st9cg3dy72kgv20l2aa8l2uv0dgqkt6ymv",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUTzNvNVh3RUFJT1hOY1o1\nV1UwNEJLeERYRElNK2dicVRWK2xWK2RtMGlJCmVScmorVWxtZ3pwcHdtd3NtVXFL\nbVdmQ2R3QlV2VVdqbVYyQ1ZoSUZuQkEKLS0tIDl3YThkTUJoWnVnT0Z5SGRqQTF3\nOVF6M3dQNTJBeWZJbnpIVVZOdm1CajgKMCN5fq763pMJ3UWEj4DaSaD7grcUaBae\nv7cW4Go92Qa4MfKGwgH95nf7swvuStE3LX9l+9srugv+sJXl2QLcdg==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-09-29T19:26:16Z",
+		"mac": "ENC[AES256_GCM,data:pm7KlE0otfVGwNmXvNO8NrAO7HDQNu8LxpgOcBNfspVR/EWEoOjnPerkJXie8mMBeODW3S2XaCRMU+i6wWzoDGV5x8M7fOKzt3xuybZr3eAcklj+TzF+xnBGkKcOMXNqUSFcgcd7WrxNPkaA14Ese8D6QnGRpNAozIOyTc8TYwc=,iv:xF/2hpe3Ilq7OBlaneKDkIiN4/O/duOjTK5WfH8EJbg=,tag:93fShCPlG7n/bMEdgvormg==,type:str]",
+		"version": "3.11.0"
+	}
+}


### PR DESCRIPTION
feat: establish sops+age baseline for secrets

- Add .sops.yaml with default age public key for encryption
- Commit example.tfvars.enc as reference encrypted file
- Update .gitignore to exclude plaintext example.tfvars
- Begin docs/runbooks/local_dev_setup.md with setup + usage steps

This fulfills Phase 1 tracker item: "Establish sops+age for encrypting static configuration examples."